### PR TITLE
Add `| integer` to `iFlags` to prevent type warning when combining flags

### DIFF
--- a/Shared/classes/baseclass.lua
+++ b/Shared/classes/baseclass.lua
@@ -196,7 +196,7 @@ end
 ---`🔸 Client`<br>`🔹 Server`<br>
 ---Creates a new class that inherits from this class
 ---@param sClassName string @The name of the new class
----@param iFlags? ClassLib.FL @The class flags to use, defaults to `nil`
+---@param iFlags? ClassLib.FL | integer @The class flags to use, defaults to `nil`
 ---@return table @The newly created class
 ---@see ClassLib.FL
 function BaseClass.Inherit(sClassName, iFlags)


### PR DESCRIPTION
<img width="827" height="153" alt="image" src="https://github.com/user-attachments/assets/32b2a834-d09d-4873-9011-e909bbfb5992" />